### PR TITLE
Fixed the version being displayed incorrectly and update button showing at the wrong time

### DIFF
--- a/flathub/application.py
+++ b/flathub/application.py
@@ -20,6 +20,9 @@ class Application:
         self.version = version
         self.available_version = available_version
 
+        if not self.version:
+            self.version = self.available_version
+
         if image_url.startswith("/"):
             self.image_url = "https://flathub.org{}".format(image_url)
         else:

--- a/views/flathub_edit.tpl
+++ b/views/flathub_edit.tpl
@@ -1,7 +1,9 @@
 % rebase('base.tpl')
 
 <h2>{{app}}</h2>
+% if app.version:
 <h3>Version: {{app.version}}</h3>
+% end
 % if app.busy:
 <script type="text/JavaScript">
     window.setTimeout("location.reload(true);", 5000)
@@ -25,6 +27,11 @@ Installing..
 % if app.version != app.available_version:
 <form action="/flathub/update/{{app.flatpak_id}}">
 	<button class="add">Update to version {{app.available_version}}</button>
+</form>
+% end
+% if not app.version:
+<form action="/flathub/update/{{app.flatpak_id}}">
+	<button class="add">Check for updates</button>
 </form>
 % end
 <form action="/flathub/uninstall/{{app.flatpak_id}}">


### PR DESCRIPTION
This fixes the following issues:
- Even if the version was not set it was being displayed
- Apllications which weren't installed would have a blank version shown instead of the available one in the flathub repo
- Updating applications which don't use a version number wasn't possible

In the case of the version not being known, there will be a check for updates button now.