### PR TITLE
Show live progress when working with flatpak

### DIFF
--- a/flathub/application.py
+++ b/flathub/application.py
@@ -20,6 +20,9 @@ class Application:
         self.version = version
         self.available_version = available_version
 
+        if not self.version:
+            self.version = self.available_version
+
         if image_url.startswith("/"):
             self.image_url = "https://flathub.org{}".format(image_url)
         else:

--- a/steam-buddy
+++ b/steam-buddy
@@ -2,9 +2,10 @@
 
 import os
 import yaml
+import json
 import shutil
 import flathub
-from bottle import route, request, static_file, run, template, redirect
+from bottle import route, request, static_file, run, template, redirect, response
 
 DATA_DIR='/var/lib/steam-buddy'
 SHORTCUT_DIR=DATA_DIR + '/shortcuts'
@@ -225,7 +226,7 @@ def flathub_install(flatpak_id):
 	shortcuts_file = "{shortcuts_dir}/{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
 	yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
 
-	redirect('/platforms/{platform}'.format(platform=platform))
+	redirect('/platforms/{platform}/edit/{name}'.format(platform=platform, name=flatpak_id))
 
 @route('/flathub/uninstall/<flatpak_id>')
 def flathub_uninstall(flatpak_id):
@@ -245,7 +246,7 @@ def flathub_uninstall(flatpak_id):
 	shortcuts_file = "{shortcuts_dir}/{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
 	yaml.dump(shortcuts, open(shortcuts_file, 'w'), default_flow_style=False)
 
-	redirect('/platforms/{platform}'.format(platform=platform))
+	redirect('/platforms/{platform}/edit/{name}'.format(platform=platform, name=flatpak_id))
 
 @route('/flathub/update/<flatpak_id>')
 def flathub_update(flatpak_id):
@@ -256,7 +257,23 @@ def flathub_update(flatpak_id):
 		redirect('/platforms/{platform}'.format(platform=platform))
 	application.update()
 
-	redirect('/platforms/{platform}'.format(platform=platform))
+	redirect('/platforms/{platform}/edit/{name}'.format(platform=platform, name=flatpak_id))
+
+@route('/flathub/progress/<flatpak_id>')
+def flathub_update(flatpak_id):
+	platform = "flathub"
+	application = FLATHUB_HANDLER.get_application(flatpak_id)
+	if not application:
+		# TODO: add a 404 here
+		redirect('/platforms/{platform}'.format(platform=platform))
+
+	response.content_type = 'application/json'
+	values = {
+		"busy": application.busy,
+		"progress": application.progress
+	}
+
+	return json.dumps(values)
 
 if __name__ == '__main__':
 	run(host='0.0.0.0', port=80)

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -23,6 +23,10 @@
 			text-decoration: none;
 		}
 
+		#progress {
+		    display : inline;
+		}
+
 		.flathub-link, .flathub-new {
 		    display : inline;
 		    float : left;

--- a/views/flathub_edit.tpl
+++ b/views/flathub_edit.tpl
@@ -1,23 +1,35 @@
 % rebase('base.tpl')
 
 <h2>{{app}}</h2>
-% if app.version:
-<h3>Version: {{app.version}}</h3>
-% end
 % if app.busy:
 <script type="text/JavaScript">
-    window.setTimeout("location.reload(true);", 5000)
+async function reloadWhenDone() {
+	base_url = location.protocol + "//" + window.location.hostname;
+	url = base_url + "/flathub/progress/" + "{{app.flatpak_id}}";
+	response = await fetch(url);
+	values = await response.json();
+	if (!values.busy) {
+	    location.reload(true);
+	} else {
+	    if (values.progress != -1) {
+	        document.getElementById('progress').innerHTML = values.progress + "%"
+	    }
+	    setTimeout(reloadWhenDone, 100);
+	}
+}
+reloadWhenDone();
 </script>
 <h3>
 % if app.installed:
-Uninstalling...
+Uninstalling... <div id="progress"></div>
 % else:
-Installing..
-% end
-% if app.progress != -1:
-{{app.progress}}&#37;
+Installing.. <div id="progress"></div>
 % end
 </h3>
+% else:
+% if app.version:
+<h3>Version: {{app.version}}</h3>
+% end
 % end
 <p ><img class="flathub-edit" src="{{app.image_url}}" alt="{{ app.name }}" title="{{ app }}"></img></p>
 {{!app.get_description()}}

--- a/views/flathub_edit.tpl
+++ b/views/flathub_edit.tpl
@@ -1,7 +1,9 @@
 % rebase('base.tpl')
 
 <h2>{{app}}</h2>
+% if app.version:
 <h3>Version: {{app.version}}</h3>
+% end
 % if app.busy:
 <script type="text/JavaScript">
     window.setTimeout("location.reload(true);", 5000)
@@ -25,6 +27,11 @@ Installing..
 % if app.version != app.available_version:
 <form action="/flathub/update/{{app.flatpak_id}}">
 	<button class="add">Update to version {{app.available_version}}</button>
+</form>
+% end
+% if not app.version:
+<form action="/flathub/update/{{app.flatpak_id}}">
+	<button class="add">Check for updates</button>
 </form>
 % end
 <form action="/flathub/uninstall/{{app.flatpak_id}}">


### PR DESCRIPTION
In the Flathub plaform show progress live on the page and refresh the page when done. This was done with some simple javascript code. The pull request for the version fix has been included in this one, since there is a conflict with it.