### PR TITLE
Fixed the name link in the top bar for flathub applications

### DIFF
--- a/steam-buddy
+++ b/steam-buddy
@@ -94,7 +94,7 @@ def edit(platform, name):
 		application = FLATHUB_HANDLER.get_application(name)
 		if application:
 			return template('flathub_edit', app=application, platform="flathub", platformName="Flathub",
-							name=application.name, )
+							name=name, )
 		else:
 			# TODO: This should probably be changed to a 404
 			redirect('/platforms/flathub')


### PR DESCRIPTION
Sorry for the spam. This one is really small, but I noticed the name in the top bar would go a page that doesn't exist.