### PR TITLE
Improved compatibility with other distributions

### DIFF
--- a/flathub/application.py
+++ b/flathub/application.py
@@ -18,7 +18,10 @@ class Application:
         self.progress = -1
         self.busy = False
         self.version = version
-        self.available_version = available_version
+        if self.version or not self.installed:
+            self.available_version = available_version
+        else:
+            self.available_version = ""
 
         if not self.version:
             self.version = self.available_version

--- a/flathub/flathub.py
+++ b/flathub/flathub.py
@@ -35,7 +35,7 @@ class Flathub:
                 version = ""
 
                 for app in installed_list:
-                    if app['flatpak_id'] == flatpak_id:
+                    if app['flatpak_id'].strip() == flatpak_id:
                         installed = True
                         version = app['version']
 
@@ -72,7 +72,11 @@ class Flathub:
         for line in subprocess.check_output(command).splitlines():
             if isinstance(line, bytes):
                 line = line.decode("utf-8")
-            _, flatpak_id, version, _ = line.split("\t", 3)
+            try:
+                _, flatpak_id, version, _ = line.split("\t", 3)
+            except ValueError:
+                flatpak_id = line
+                version = ""
             application_tuple = {
                 'flatpak_id': flatpak_id,
                 'version': version

--- a/steam-buddy
+++ b/steam-buddy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import yaml
@@ -29,7 +29,7 @@ def load_shortcuts(platform):
 		os.makedirs(SHORTCUT_DIR)
 	shortcuts_file = "{shortcuts_dir}/{platform}.yaml".format(shortcuts_dir=SHORTCUT_DIR, platform=platform)
 	if os.path.isfile(shortcuts_file):
-		shortcuts = yaml.load(open(shortcuts_file), Loader=yaml.FullLoader)
+		shortcuts = yaml.load(open(shortcuts_file), Loader=yaml.Loader)
 
 	if not shortcuts:
 		shortcuts = []


### PR DESCRIPTION
This pull request makes steam-buddy able to run on systems as old as Debian 9.
I've tested it on Arch and Debian 9.

It also fixes an issue with version numbers. Before it would sometimes show the wrong update button when the version was unknown.