### PR TITLE
Add a settings menu and FTP server support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ wheel
 pyyaml
 bottle
 requests
+pyftpdlib

--- a/steam-buddy
+++ b/steam-buddy
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import os
 from steam_buddy import server
-from steam_buddy.config import RESOURCE_DIR
+from steam_buddy.config import RESOURCE_DIR, FTP_SERVER
 
 if __name__ == '__main__':
 	os.chdir(RESOURCE_DIR)
+	FTP_SERVER.run()
 	server.run(host='localhost', port=8844)

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -1,6 +1,7 @@
 import os
 from steam_buddy.flathub import Flathub
 from steam_buddy.settings import Settings
+from steam_buddy.ftp.server import Server as FTPServer
 
 DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
@@ -37,3 +38,5 @@ SETTINGS_DEFAULT = {
 FLATHUB_HANDLER = Flathub()
 
 SETTINGS_HANDLER = Settings(SETTINGS_DIR, SETTINGS_DEFAULT)
+
+FTP_SERVER = FTPServer(SETTINGS_HANDLER)

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -1,5 +1,6 @@
 import os
 from steam_buddy.flathub import Flathub
+from steam_buddy.settings import Settings
 
 DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
@@ -10,6 +11,7 @@ if not os.path.isfile(os.path.join(RESOURCE_DIR, 'views/base.tpl')):
 SHORTCUT_DIR = DATA_DIR + '/steam-shortcuts'
 BANNER_DIR = DATA_DIR + '/steam-buddy/banners'
 CONTENT_DIR = DATA_DIR + '/steam-buddy/content'
+SETTINGS_DIR = DATA_DIR + '/steam-buddy/settings'
 
 PLATFORMS = {
 	"flathub": 	"Flathub",
@@ -25,4 +27,13 @@ PLATFORMS = {
 	"tg-16":	"TurboGrafx-16"
 }
 
+SETTINGS_DEFAULT = {
+	"enable_ftp_server": False,
+	"ftp_username": "gamer",
+	"ftp_password": "gamer",
+	"ftp_port": 2121
+}
+
 FLATHUB_HANDLER = Flathub()
+
+SETTINGS_HANDLER = Settings(SETTINGS_DIR, SETTINGS_DEFAULT)

--- a/steam_buddy/ftp/server.py
+++ b/steam_buddy/ftp/server.py
@@ -1,0 +1,60 @@
+import os
+import threading
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.handlers import FTPHandler
+from pyftpdlib.servers import FTPServer
+
+
+class Server:
+
+    def __init__(self, settings):
+        self.settings = settings
+        self.username = self.settings.get_setting("ftp_username")
+        self.password = self.settings.get_setting("ftp_password")
+        self.port = self.settings.get_setting("ftp_port")
+        self.enabled = self.settings.get_setting("enable_ftp_server")
+        self.__server = None
+
+    def run(self):
+        authorizer = DummyAuthorizer()
+        authorizer.add_user(self.username, self.password, os.environ['HOME'], perm="elradfmw")
+
+        handler = FTPHandler
+        handler.authorizer = authorizer
+
+        self.__server = FTPServer(('0.0.0.0', self.port), handler)
+
+        if self.enabled:
+            ftp_thread = threading.Thread(target=self.__server.serve_forever)
+            ftp_thread.daemon = True
+            ftp_thread.start()
+
+    def stop(self):
+        if self.__server:
+            self.__server.close_all()
+
+    def reload(self):
+        new_enabled = self.settings.get_setting("enable_ftp_server")
+        new_username = self.settings.get_setting("ftp_username")
+        new_password = self.settings.get_setting("ftp_password")
+        new_port = self.settings.get_setting("ftp_port")
+
+        # Check if any of the values were changed
+        settings_were_changed = False
+        if new_enabled != self.enabled:
+            self.enabled = new_enabled
+            settings_were_changed = True
+        if new_username != self.username:
+            self.username = new_username
+            settings_were_changed = True
+        if new_password != self.password:
+            self.password = new_password
+            settings_were_changed = True
+        if new_port != self.port:
+            self.port = new_port
+            settings_were_changed = True
+
+        # Reload the server if any changes were found
+        if settings_were_changed:
+            self.stop()
+            self.run()

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -3,7 +3,7 @@ import subprocess
 import json
 import yaml
 from bottle import Bottle, template, static_file, redirect, abort, request, response
-from steam_buddy.config import PLATFORMS, FLATHUB_HANDLER, SETTINGS_HANDLER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR
+from steam_buddy.config import PLATFORMS, FLATHUB_HANDLER, SETTINGS_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR
 from steam_buddy.functions import load_shortcuts, sanitize, upsert_file, delete_file
 
 server = Bottle()
@@ -268,6 +268,8 @@ def settings_update():
     ftp_port = int(sanitize(request.forms.get('ftp_port')))
     if ftp_port and 1024 < ftp_port < 65536 and ftp_port != 8844:
         SETTINGS_HANDLER.set_setting("ftp_port", ftp_port)
+
+    FTP_SERVER.reload()
 
     redirect('/settings')
 

--- a/steam_buddy/settings.py
+++ b/steam_buddy/settings.py
@@ -1,0 +1,42 @@
+import os
+import json
+
+
+class Settings:
+
+    def __init__(self, settings_directory, settings_default):
+        self.settings_directory = settings_directory
+        self.settings_default = settings_default
+        self.settings_file = os.path.join(self.settings_directory, "settings.json")
+        # Make sure a settings file with all expected values exists
+        self.__add_new_settings()
+
+    def __add_new_settings(self):
+        if not os.path.isdir(self.settings_directory):
+            os.makedirs(self.settings_directory)
+        settings = self.get_settings()
+        for key in self.settings_default:
+            try:
+                settings[key]
+            except KeyError:
+                self.set_setting(key, self.settings_default[key])
+
+    def set_setting(self, key, value) -> None:
+        settings = self.get_settings()
+        settings[key] = value
+        with open(self.settings_file, "w") as file:
+            file.write(json.dumps(settings))
+            file.close()
+
+    def get_setting(self, setting: str) -> any:
+        with open(self.settings_file, "r") as file:
+            settings = json.loads(file.read())
+            return settings[setting]
+
+    def get_settings(self) -> dict:
+        if os.path.isfile(self.settings_file):
+            with open(self.settings_file, "r") as file:
+                return json.loads(file.read())
+        return {}
+
+

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -210,6 +210,7 @@
 		% end
 		<div class="right">
             <div id="menuitems">
+                <a href="/settings">Settings</a>
                 <a href="/steam/restart">Restart Steam</a>
                 <a href="/steam/compositor">Toggle Compositor</a>
             </div>

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -1,0 +1,16 @@
+% rebase('base.tpl')
+<form action="/settings/update" method="post" enctype="multipart/form-data">
+	<div class="label">Enable FTP server</div>
+	<input type="checkbox" name="enable_ftp_server" {{'checked' if settings["enable_ftp_server"] else ''}} />
+
+	<div class="label">FTP username</div>
+	<input name="ftp_username" value="{{settings["ftp_username"]}}" />
+
+	<div class="label">FTP password</div>
+	<input name="ftp_password" value="{{settings["ftp_password"]}}"" />
+
+    <div class="label">FTP port</div>
+	<input type="number" name="ftp_port" value="{{settings["ftp_port"]}}"" />
+
+	<button>Save</button>
+</form>


### PR DESCRIPTION
This pull requests adds a settings option to the gear in the top right which brings you to a settings menu. Within this menu an FTP server can be enabled and configured. This works quite well currently.

It uses a json file called settings.json to save the ftp configuration. Other settings could be added to this as well.

This implementation has a couple of limitations:
- It requires the pyftpdlib to be added to the dependencies of the package. This library can be found [here](https://www.archlinux.org/packages/community/any/python-pyftpdlib/) in the Arch repository.
- Saving settings is not thread-safe currently. Multiple functions writing to it at the same time has  the potential to corrupt the settings file. Currently this should never happen. Reading from it is thread-safe.