### PR TITLE
Added support for authentication using a full screen application and random password

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt flake8 WebTest
+        pip install -r requirements-test.txt
     - name: Lint with flake8
       run: |
         flake8 . --count --max-complexity=10 --max-line-length=127 --show-source --statistics --exit-zero

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ beaker
 psutil
 flake8
 WebTest
+bcrypt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,9 @@
+wheel
+pyyaml
+bottle
+requests
+pyftpdlib
+beaker
+psutil
+flake8
+WebTest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ bottle
 requests
 pyftpdlib
 beaker
+pygame

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 bottle
 requests
 pyftpdlib
+beaker

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyftpdlib
 beaker
 pygame
 psutil
+bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 pyftpdlib
 beaker
 pygame
+psutil

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from glob import glob
 
 setup(
     name="Steam-Buddy",
-    version="0.1.5",
+    version="0.4.0",
     packages=find_packages(),
     scripts=['steam-buddy'],
 
@@ -26,6 +26,9 @@ setup(
         'bottle',
         'pyyaml',
         'requests',
+        'beaker',
+        'pygame',
+        'psutil',
     ],
 
     # metadata to display on PyPI

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         ('share/steam-buddy', ['launcher']),
         ('bin', glob('bin/*')),
         ('bin', ['toggle-steamos-compositor']),
+        ('share/steam-buddy/bin', ['steam-buddy-authenticator'])
         ('share/doc/steam-buddy', ['README.md']),
         ('share/doc/steam-buddy', ['LICENSE']),
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         ('share/steam-buddy', ['launcher']),
         ('bin', glob('bin/*')),
         ('bin', ['toggle-steamos-compositor']),
-        ('share/steam-buddy/bin', ['steam-buddy-authenticator'])
+        ('share/steam-buddy/bin', ['steam-buddy-authenticator']),
         ('share/doc/steam-buddy', ['README.md']),
         ('share/doc/steam-buddy', ['LICENSE']),
     ],

--- a/steam-buddy
+++ b/steam-buddy
@@ -7,4 +7,4 @@ from steam_buddy.config import RESOURCE_DIR, FTP_SERVER
 if __name__ == '__main__':
 	os.chdir(RESOURCE_DIR)
 	FTP_SERVER.run()
-	bottle.run(app=server, host='localhost', port=8844)
+	bottle.run(app=server, host='0.0.0.0', port=8844)

--- a/steam-buddy
+++ b/steam-buddy
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import os
+import bottle
 from steam_buddy import server
 from steam_buddy.config import RESOURCE_DIR, FTP_SERVER
 
 if __name__ == '__main__':
 	os.chdir(RESOURCE_DIR)
 	FTP_SERVER.run()
-	server.run(host='localhost', port=8844)
+	bottle.run(app=server, host='localhost', port=8844)

--- a/steam-buddy-authenticator
+++ b/steam-buddy-authenticator
@@ -39,7 +39,7 @@ password_text_rect = pygame.Rect(
     password_text.get_height()
 )
 
-instructions_text = font.render("Your password for http://gameros.local/ is:", True, Color.TEXT)
+instructions_text = font.render("Your password for the web interface is:", True, Color.TEXT)
 instructions_text_rect = pygame.Rect(
     int(screen.get_width() / 2 - instructions_text.get_width() / 2),
     font_size,

--- a/steam-buddy-authenticator
+++ b/steam-buddy-authenticator
@@ -11,9 +11,10 @@ class Color:
 # init pygame
 pygame.init()
 clock = pygame.time.Clock()
-font = pygame.font.SysFont('dejavusans', 96)
-large_font = pygame.font.SysFont('dejavusans', 128, bold=True)
 screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.HWSURFACE | pygame.DOUBLEBUF)
+font_size = int(screen.get_width()/26)
+font = pygame.font.SysFont('dejavusans', font_size)
+large_font = pygame.font.SysFont('dejavusans', font_size*2, bold=True)
 
 # Setup joystick
 pygame.joystick.init()
@@ -25,24 +26,24 @@ for joystick in joysticks:
 password = SETTINGS_HANDLER.get_setting('password')
 password_text = large_font.render(password, True, Color.TEXT)
 password_text_rect = pygame.Rect(
-    screen.get_width() / 2 - password_text.get_width() / 2,
-    screen.get_height() / 2 - password_text.get_height() / 2,
+    int(screen.get_width() / 2 - password_text.get_width() / 2),
+    int(screen.get_height() / 2 - password_text.get_height() / 2),
     password_text.get_width(),
     password_text.get_height()
 )
 
 instructions_text = font.render("Your password for http://gameros.local/ is:", True, Color.TEXT)
 instructions_text_rect = pygame.Rect(
-    screen.get_width() / 2 - instructions_text.get_width() / 2,
-    96,
+    int(screen.get_width() / 2 - instructions_text.get_width() / 2),
+    font_size,
     instructions_text.get_width(),
     instructions_text.get_height()
 )
 
 quit_text = font.render("Press any button to exit this screen", True, Color.TEXT)
 quit_text_rect = pygame.Rect(
-    screen.get_width() / 2 - quit_text.get_width() / 2,
-    screen.get_height() - quit_text.get_height()*1.5 - 96,
+    int(screen.get_width() / 2 - quit_text.get_width() / 2),
+    int(screen.get_height() - quit_text.get_height()*1.5 - font_size),
     instructions_text.get_width(),
     instructions_text.get_height()
 )

--- a/steam-buddy-authenticator
+++ b/steam-buddy-authenticator
@@ -77,7 +77,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-
-
-

--- a/steam-buddy-authenticator
+++ b/steam-buddy-authenticator
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
+import sys
 import pygame
-from steam_buddy.config import SETTINGS_HANDLER
 
 
 class Color:
     TEXT = 252, 252, 252
     BACKGROUND = 15, 47, 78
+
+
+# Load the password from the command line arguments
+if len(sys.argv) > 1:
+    password = sys.argv[1]
+else:
+    print("No password to show specified")
+    exit(1)
 
 
 # init pygame
@@ -23,7 +31,6 @@ for joystick in joysticks:
     joystick.init()
 
 # Create text to display on screen
-password = SETTINGS_HANDLER.get_setting('password')
 password_text = large_font.render(password, True, Color.TEXT)
 password_text_rect = pygame.Rect(
     int(screen.get_width() / 2 - password_text.get_width() / 2),

--- a/steam-buddy-authenticator
+++ b/steam-buddy-authenticator
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import pygame
+from steam_buddy.config import SETTINGS_HANDLER
+
+
+class Color:
+    TEXT = 252, 252, 252
+    BACKGROUND = 15, 47, 78
+
+
+# init pygame
+pygame.init()
+clock = pygame.time.Clock()
+font = pygame.font.SysFont('dejavusans', 96)
+large_font = pygame.font.SysFont('dejavusans', 128, bold=True)
+screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN | pygame.HWSURFACE | pygame.DOUBLEBUF)
+
+# Setup joystick
+pygame.joystick.init()
+joysticks = [pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())]
+for joystick in joysticks:
+    joystick.init()
+
+# Create text to display on screen
+password = SETTINGS_HANDLER.get_setting('password')
+password_text = large_font.render(password, True, Color.TEXT)
+password_text_rect = pygame.Rect(
+    screen.get_width() / 2 - password_text.get_width() / 2,
+    screen.get_height() / 2 - password_text.get_height() / 2,
+    password_text.get_width(),
+    password_text.get_height()
+)
+
+instructions_text = font.render("Your password for http://gameros.local/ is:", True, Color.TEXT)
+instructions_text_rect = pygame.Rect(
+    screen.get_width() / 2 - instructions_text.get_width() / 2,
+    96,
+    instructions_text.get_width(),
+    instructions_text.get_height()
+)
+
+quit_text = font.render("Press any button to exit this screen", True, Color.TEXT)
+quit_text_rect = pygame.Rect(
+    screen.get_width() / 2 - quit_text.get_width() / 2,
+    screen.get_height() - quit_text.get_height()*1.5 - 96,
+    instructions_text.get_width(),
+    instructions_text.get_height()
+)
+
+
+def exit_button_was_pressed() -> bool:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            return True
+        elif event.type == pygame.KEYDOWN:
+            return True
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            return True
+        elif event.type == pygame.JOYBUTTONDOWN:
+            if event.button in range(0, 11):
+                return True
+        return False
+
+
+def main():
+    while 1:
+        if exit_button_was_pressed():
+            break
+        screen.fill(Color.BACKGROUND)
+        screen.blit(instructions_text, instructions_text_rect)
+        screen.blit(password_text, password_text_rect)
+        screen.blit(quit_text, quit_text_rect)
+        pygame.display.update()
+        clock.tick(30)
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()
+
+
+
+

--- a/steam_buddy/authenticator.py
+++ b/steam_buddy/authenticator.py
@@ -5,13 +5,16 @@ from steam_buddy.config import AUTHENTICATOR_PATH
 
 
 def launch_authenticator():
-    print("trying things")
+    print("Showing authenticator on screen")
     if not os.environ.get("DISPLAY"):
         os.environ["DISPLAY"] = ":0.0"
-    already_running = False
+    kill_authenticator()
+    subprocess.Popen([AUTHENTICATOR_PATH])
+
+
+def kill_authenticator():
     for process in psutil.process_iter():
         if AUTHENTICATOR_PATH in process.cmdline():
-            already_running = True
+            print("Stopping authenticator")
+            process.kill()
             break
-    if not already_running:
-        subprocess.Popen([AUTHENTICATOR_PATH])

--- a/steam_buddy/authenticator.py
+++ b/steam_buddy/authenticator.py
@@ -5,19 +5,21 @@ import subprocess
 import psutil
 
 
+def generate_password(length: int) -> str:
+    alphabet = string.ascii_letters + string.digits
+    password = ''.join(secrets.choice(alphabet) for i in range(length))
+    return password
+
+
 class Authenticator:
     def __init__(self, authenticator_path: str, password_length: int):
         self.__app = authenticator_path
         self.__password_length = password_length
-        self.__password = self.__make_password()
+        self.__password = generate_password(self.__password_length)
 
-    def __make_password(self) -> str:
-        alphabet = string.ascii_letters + string.digits
-        password = ''.join(secrets.choice(alphabet) for i in range(self.__password_length))
-        return password
 
     def reset_password(self) -> None:
-        self.__password = self.__make_password()
+        self.__password = generate_password(self.__password_length)
 
     def matches_password(self, password):
         if password == self.__password:

--- a/steam_buddy/authenticator.py
+++ b/steam_buddy/authenticator.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+import psutil
+from steam_buddy.config import AUTHENTICATOR_PATH
+
+
+def launch_authenticator():
+    print("trying things")
+    if not os.environ.get("DISPLAY"):
+        os.environ["DISPLAY"] = ":0.0"
+    already_running = False
+    for process in psutil.process_iter():
+        if AUTHENTICATOR_PATH in process.cmdline():
+            already_running = True
+            break
+    if not already_running:
+        subprocess.Popen([AUTHENTICATOR_PATH])

--- a/steam_buddy/authenticator.py
+++ b/steam_buddy/authenticator.py
@@ -7,10 +7,11 @@ import psutil
 
 def generate_password(length: int) -> str:
     alphabet = string.ascii_uppercase + string.digits
-    # Exclude the O, I and 0
+    # Exclude the O, I, J and 0
     alphabet = alphabet.replace("O", "")
     alphabet = alphabet.replace("I", "")
     alphabet = alphabet.replace("0", "")
+    alphabet = alphabet.replace("J", "")  # Looks too much like a lowercase letter
     password = ''.join(secrets.choice(alphabet) for i in range(length))
     return password
 

--- a/steam_buddy/authenticator.py
+++ b/steam_buddy/authenticator.py
@@ -6,7 +6,11 @@ import psutil
 
 
 def generate_password(length: int) -> str:
-    alphabet = string.ascii_letters + string.digits
+    alphabet = string.ascii_uppercase + string.digits
+    # Exclude the O, I and 0
+    alphabet = alphabet.replace("O", "")
+    alphabet = alphabet.replace("I", "")
+    alphabet = alphabet.replace("0", "")
     password = ''.join(secrets.choice(alphabet) for i in range(length))
     return password
 
@@ -16,7 +20,6 @@ class Authenticator:
         self.__app = authenticator_path
         self.__password_length = password_length
         self.__password = generate_password(self.__password_length)
-
 
     def reset_password(self) -> None:
         self.__password = generate_password(self.__password_length)

--- a/steam_buddy/authenticator.py
+++ b/steam_buddy/authenticator.py
@@ -1,20 +1,39 @@
 import os
+import secrets
+import string
 import subprocess
 import psutil
-from steam_buddy.config import AUTHENTICATOR_PATH
 
 
-def launch_authenticator():
-    print("Showing authenticator on screen")
-    if not os.environ.get("DISPLAY"):
-        os.environ["DISPLAY"] = ":0.0"
-    kill_authenticator()
-    subprocess.Popen([AUTHENTICATOR_PATH])
+class Authenticator:
+    def __init__(self, authenticator_path: str, password_length: int):
+        self.__app = authenticator_path
+        self.__password_length = password_length
+        self.__password = self.__make_password()
 
+    def __make_password(self) -> str:
+        alphabet = string.ascii_letters + string.digits
+        password = ''.join(secrets.choice(alphabet) for i in range(self.__password_length))
+        return password
 
-def kill_authenticator():
-    for process in psutil.process_iter():
-        if AUTHENTICATOR_PATH in process.cmdline():
-            print("Stopping authenticator")
-            process.kill()
-            break
+    def reset_password(self) -> None:
+        self.__password = self.__make_password()
+
+    def matches_password(self, password):
+        if password == self.__password:
+            return True
+        return False
+
+    def launch(self) -> None:
+        print("Showing authenticator on screen")
+        if not os.environ.get("DISPLAY"):
+            os.environ["DISPLAY"] = ":0.0"
+        self.kill()
+        subprocess.Popen([self.__app, self.__password])
+
+    def kill(self):
+        for process in psutil.process_iter():
+            if self.__app in process.cmdline():
+                print("Stopping authenticator")
+                process.kill()
+                break

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -37,10 +37,9 @@ PLATFORMS = {
 SETTINGS_DEFAULT = {
 	"enable_ftp_server": False,
 	"ftp_username": "gamer",
-	"ftp_password": "gamer",
+	"ftp_password": generate_password(12),
 	"ftp_port": 2121,
-	"keep_password": False,
-	"password": generate_password(12),
+	"keep_password": False
 }
 
 SESSION_OPTIONS = {

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -1,8 +1,8 @@
 import os
-import secrets
 from steam_buddy.flathub import Flathub
 from steam_buddy.settings import Settings
 from steam_buddy.ftp.server import Server as FTPServer
+from steam_buddy.authenticator import Authenticator
 
 DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
@@ -53,5 +53,7 @@ SESSION_OPTIONS = {
 FLATHUB_HANDLER = Flathub()
 
 SETTINGS_HANDLER = Settings(SETTINGS_DIR, SETTINGS_DEFAULT)
+
+AUTHENTICATOR = Authenticator(AUTHENTICATOR_PATH, password_length=8)
 
 FTP_SERVER = FTPServer(SETTINGS_HANDLER)

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -2,7 +2,7 @@ import os
 from steam_buddy.flathub import Flathub
 from steam_buddy.settings import Settings
 from steam_buddy.ftp.server import Server as FTPServer
-from steam_buddy.authenticator import Authenticator
+from steam_buddy.authenticator import Authenticator, generate_password
 
 DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
@@ -39,7 +39,8 @@ SETTINGS_DEFAULT = {
 	"ftp_username": "gamer",
 	"ftp_password": "gamer",
 	"ftp_port": 2121,
-	"keep_password": False
+	"keep_password": False,
+	"password": generate_password(12),
 }
 
 SESSION_OPTIONS = {

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -10,6 +10,10 @@ RESOURCE_DIR = os.getcwd()
 if not os.path.isfile(os.path.join(RESOURCE_DIR, 'views/base.tpl')):
 	RESOURCE_DIR = "/usr/share/steam-buddy"
 
+AUTHENTICATOR_PATH = os.path.abspath('steam-buddy-authenticator')
+if not os.path.isfile(AUTHENTICATOR_PATH):
+	AUTHENTICATOR_PATH = "/usr/share/steam-buddy/bin/steam-buddy-authenticator"
+
 SHORTCUT_DIR = DATA_DIR + '/steam-shortcuts'
 BANNER_DIR = DATA_DIR + '/steam-buddy/banners'
 CONTENT_DIR = DATA_DIR + '/steam-buddy/content'

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 from steam_buddy.flathub import Flathub
 from steam_buddy.settings import Settings
 from steam_buddy.ftp.server import Server as FTPServer
@@ -34,6 +35,15 @@ SETTINGS_DEFAULT = {
 	"ftp_username": "gamer",
 	"ftp_password": "gamer",
 	"ftp_port": 2121
+}
+
+SESSION_OPTIONS = {
+	'session.cookie_expires': True,
+	'session.encrypt_key': secrets.token_urlsafe(64),
+	'session.httponly': True,
+	'session.timeout': 3600 * 2,
+	'session.type': 'cookie',
+	'session.validate_key': True,
 }
 
 FLATHUB_HANDLER = Flathub()

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -44,10 +44,9 @@ SETTINGS_DEFAULT = {
 
 SESSION_OPTIONS = {
 	'session.cookie_expires': True,
-	'session.encrypt_key': secrets.token_urlsafe(64),
 	'session.httponly': True,
 	'session.timeout': 3600 * 2,
-	'session.type': 'cookie',
+	'session.type': 'memory',
 	'session.validate_key': True,
 }
 

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -34,7 +34,8 @@ SETTINGS_DEFAULT = {
 	"enable_ftp_server": False,
 	"ftp_username": "gamer",
 	"ftp_password": "gamer",
-	"ftp_port": 2121
+	"ftp_port": 2121,
+	"keep_password": False
 }
 
 SESSION_OPTIONS = {

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -336,7 +336,7 @@ def login():
         alphabet = string.ascii_letters + string.digits
         password = ''.join(secrets.choice(alphabet) for i in range(8))
         SETTINGS_HANDLER.set_setting('password', password)
-    return template('login')
+    return template('login', keep_password=SETTINGS_HANDLER.get_setting("password"))
 
 
 @route('/logout')

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -361,7 +361,7 @@ def login():
 def logout():
     session = request.environ.get('beaker.session')
     session.delete()
-    return redirect('/login')
+    return template('logout')
 
 
 @route('/authenticate', method='POST')

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -8,7 +8,7 @@ from bottle import app, route, template, static_file, redirect, abort, request, 
 from beaker.middleware import SessionMiddleware
 from steam_buddy.config import PLATFORMS, FLATHUB_HANDLER, SETTINGS_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR, SESSION_OPTIONS
 from steam_buddy.functions import load_shortcuts, sanitize, upsert_file, delete_file
-from steam_buddy.authenticator import launch_authenticator
+from steam_buddy.authenticator import launch_authenticator, kill_authenticator
 
 server = SessionMiddleware(app(), SESSION_OPTIONS)
 
@@ -352,6 +352,7 @@ def logout():
 
 @route('/authenticate', method='POST')
 def authenticate():
+    kill_authenticator()
     password = request.forms.get('password')
     expected_password = SETTINGS_HANDLER.get_setting("password")
     session = request.environ.get('beaker.session')

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -297,10 +297,18 @@ def settings():
 @authenticate
 def settings_update():
     SETTINGS_HANDLER.set_setting("keep_password", sanitize(request.forms.get('generate_password')) != 'on')
-    SETTINGS_HANDLER.set_setting("password", sanitize(request.forms.get('login_password')))
     SETTINGS_HANDLER.set_setting("enable_ftp_server", sanitize(request.forms.get('enable_ftp_server')) == 'on')
     SETTINGS_HANDLER.set_setting("ftp_username", sanitize(request.forms.get('ftp_username')))
-    SETTINGS_HANDLER.set_setting("ftp_password", sanitize(request.forms.get('ftp_password')))
+
+    # Make sure the FTP password is long enough
+    ftp_password = sanitize(request.forms.get('ftp_password'))
+    if len(ftp_password) > 7:
+        SETTINGS_HANDLER.set_setting("ftp_password", ftp_password)
+
+    # Make sure the FTP password is long enough
+    login_password = sanitize(request.forms.get('login_password'))
+    if len(login_password) > 7:
+        SETTINGS_HANDLER.set_setting("password", login_password)
 
     # port number for FTP server
     ftp_port = int(sanitize(request.forms.get('ftp_port')))

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -354,7 +354,7 @@ def login():
     if not keep_password:
         AUTHENTICATOR.reset_password()
         AUTHENTICATOR.launch()
-    return template('login', keep_password=keep_password)
+    return template('login', keep_password=keep_password, failed=False)
 
 
 @route('/logout')
@@ -380,4 +380,4 @@ def authenticate():
         if session.get('Logged-In', True):
             session['Logged-In'] = False
             session.save()
-        redirect('/login')
+        return template('login', keep_password=keep_password, failed=True)

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -369,9 +369,9 @@ def authenticate():
     AUTHENTICATOR.kill()
     password = request.forms.get('password')
     session = request.environ.get('beaker.session')
-    keep_password = SETTINGS_HANDLER.get_setting('keep_password')
-    stored_hash = SETTINGS_HANDLER.get_setting('password').encode('utf-8')
-    if AUTHENTICATOR.matches_password(password) or keep_password and bcrypt.checkpw(password.encode('utf-8'), stored_hash):
+    keep_password = SETTINGS_HANDLER.get_setting('keep_password') or False
+    stored_hash = SETTINGS_HANDLER.get_setting('password')
+    if AUTHENTICATOR.matches_password(password) or keep_password and bcrypt.checkpw(password.encode('utf-8'), stored_hash.encode('utf-8')):
         session['User-Agent'] = request.headers.get('User-Agent')
         session['Logged-In'] = True
         session.save()
@@ -380,4 +380,7 @@ def authenticate():
         if session.get('Logged-In', True):
             session['Logged-In'] = False
             session.save()
+        if not keep_password:
+            AUTHENTICATOR.reset_password()
+            AUTHENTICATOR.launch()
         return template('login', keep_password=keep_password, failed=True)

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -332,14 +332,15 @@ def steam_compositor():
 
 @route('/login')
 def login():
+    keep_password = SETTINGS_HANDLER.get_setting('keep_password')
     session = request.environ.get('beaker.session')
-    if not SETTINGS_HANDLER.get_setting('keep_password'):
+    if not keep_password:
         if session.get('Logged-In', True):
             alphabet = string.ascii_letters + string.digits
             password = ''.join(secrets.choice(alphabet) for i in range(8))
             SETTINGS_HANDLER.set_setting('password', password)
         launch_authenticator()
-    return template('login', keep_password=SETTINGS_HANDLER.get_setting("password"))
+    return template('login', keep_password=keep_password)
 
 
 @route('/logout')

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -105,7 +105,6 @@ def flathub_images(filename):
 
 
 @route('/images/<filename>')
-@authenticate
 def images(filename):
     return static_file(filename, root=os.path.join(RESOURCE_DIR, 'images'))
 

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -317,7 +317,7 @@ def settings_update():
 
     # Only allow enabling keep password if a password is set
     keep_password = sanitize(request.forms.get('generate_password')) != 'on'
-    if keep_password and SETTINGS_HANDLER.get_setting('password'):
+    if keep_password and SETTINGS_HANDLER.get_setting('password') or not keep_password:
         SETTINGS_HANDLER.set_setting("keep_password", keep_password)
 
     # port number for FTP server

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -14,8 +14,9 @@ def authenticate(func):
     def wrapper(*args, **kwargs):
         authenticated = True
         session = request.environ.get('beaker.session')
-        print(session.get('Cookie'))
-        if not session.get('User-Agent') or session.get('User-Agent') != request.headers.get('User-Agent'):
+        if not session.get('Logged-In') or not session['Logged-In']:
+            authenticated = False
+        elif not session.get('User-Agent') or session['User-Agent'] != request.headers.get('User-Agent'):
             authenticated = False
         if not authenticated:
             return redirect('/login')
@@ -328,6 +329,14 @@ def login():
     return template('login')
 
 
+@route('/logout')
+def logout():
+    session = request.environ.get('beaker.session')
+    session['Logged-In'] = False
+    session.save()
+    return redirect('/login')
+
+
 @route('/authenticate', method='POST')
 def authenticate():
     password = request.forms.get('password')
@@ -335,6 +344,7 @@ def authenticate():
     if expected_password and password == expected_password:
         session = request.environ.get('beaker.session')
         session['User-Agent'] = request.headers.get('User-Agent')
+        session['Logged-In'] = True
         session.save()
         redirect('/')
     else:

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -296,6 +296,8 @@ def settings():
 @route('/settings/update', method='POST')
 @authenticate
 def settings_update():
+    SETTINGS_HANDLER.set_setting("keep_password", sanitize(request.forms.get('generate_password')) != 'on')
+    SETTINGS_HANDLER.set_setting("password", sanitize(request.forms.get('login_password')))
     SETTINGS_HANDLER.set_setting("enable_ftp_server", sanitize(request.forms.get('enable_ftp_server')) == 'on')
     SETTINGS_HANDLER.set_setting("ftp_username", sanitize(request.forms.get('ftp_username')))
     SETTINGS_HANDLER.set_setting("ftp_password", sanitize(request.forms.get('ftp_password')))
@@ -349,7 +351,9 @@ def authenticate():
     AUTHENTICATOR.kill()
     password = request.forms.get('password')
     session = request.environ.get('beaker.session')
-    if AUTHENTICATOR.matches_password(password):
+    keep_password = SETTINGS_HANDLER.get_setting('keep_password')
+    expected_password = SETTINGS_HANDLER.get_setting('password')
+    if AUTHENTICATOR.matches_password(password) or keep_password and password == expected_password:
         session['User-Agent'] = request.headers.get('User-Agent')
         session['Logged-In'] = True
         session.save()

--- a/steam_buddy/settings.py
+++ b/steam_buddy/settings.py
@@ -38,5 +38,3 @@ class Settings:
             with open(self.settings_file, "r") as file:
                 return json.loads(file.read())
         return {}
-
-

--- a/steam_buddy/settings.py
+++ b/steam_buddy/settings.py
@@ -31,7 +31,10 @@ class Settings:
     def get_setting(self, setting: str) -> any:
         with open(self.settings_file, "r") as file:
             settings = json.loads(file.read())
-            return settings[setting]
+            try:
+                return settings[setting]
+            except KeyError:
+                return None
 
     def get_settings(self) -> dict:
         if os.path.isfile(self.settings_file):

--- a/tests/webtests.py
+++ b/tests/webtests.py
@@ -6,15 +6,9 @@ from steam_buddy.config import PLATFORMS
 
 class WebTests(unittest.TestCase):
 
-    def test_home(self):
+    def test_runs(self):
         app = TestApp(server)
-
-        assert app.get('/').status == '200 OK'
-
-    def test_platform_pages(self):
-        app = TestApp(server)
-        for platform, name in PLATFORMS.items():
-            assert app.get('/platforms/{}'.format(platform)).status == '200 OK'
+        assert app.get('/login').status == '200 OK'
 
     def test_platform_images(self):
         app = TestApp(server)

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -213,6 +213,7 @@
                 <a href="/settings">Settings</a>
                 <a href="/steam/restart">Restart Steam</a>
                 <a href="/steam/compositor">Toggle Compositor</a>
+                <a href="/logout">Log Out</a>
             </div>
             <a href="javascript:void(0);" class="icon" onclick="toggleMenu()">&#9881;</a>
 		</div>

--- a/views/login.tpl
+++ b/views/login.tpl
@@ -4,6 +4,9 @@
 % else:
 <h3>Please enter the password shown on your TV to continue</h3>
 % end
+% if failed:
+    Given password was incorrect!
+% end
 <form action="/authenticate" method="post" enctype="multipart/form-data">
 	<div class="label">Password</div>
 	<input type="password" name="password"/>

--- a/views/login.tpl
+++ b/views/login.tpl
@@ -3,7 +3,6 @@
 <h3>Please enter your password to continue</h3>
 % else:
 <h3>Please enter the password shown on your TV to continue</h3>
-
 % end
 <form action="/authenticate" method="post" enctype="multipart/form-data">
 	<div class="label">Password</div>

--- a/views/login.tpl
+++ b/views/login.tpl
@@ -1,0 +1,8 @@
+% rebase('base.tpl')
+<h3>Please enter the password shown on your TV to continue</h3>
+<form action="/authenticate" method="post" enctype="multipart/form-data">
+	<div class="label">Password</div>
+	<input type="password" name="password"/>
+
+	<button>Login</button>
+</form>

--- a/views/login.tpl
+++ b/views/login.tpl
@@ -1,5 +1,10 @@
 % rebase('base.tpl')
+% if keep_password:
+<h3>Please enter your password to continue</h3>
+% else:
 <h3>Please enter the password shown on your TV to continue</h3>
+
+% end
 <form action="/authenticate" method="post" enctype="multipart/form-data">
 	<div class="label">Password</div>
 	<input type="password" name="password"/>

--- a/views/logout.tpl
+++ b/views/logout.tpl
@@ -1,0 +1,2 @@
+% rebase('base.tpl')
+You've been logged out successfully.

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -1,16 +1,56 @@
 % rebase('base.tpl')
 <form action="/settings/update" method="post" enctype="multipart/form-data">
+    <h4>Logging in</h4>
+    <hr>
+    <div class="label">Generate a new password for each login</div>
+	<input type="checkbox" name="generate_password" id="generate_password" onclick="setShowPasswordField()" {{'checked' if not settings["keep_password"] else ''}} />
+
+    <div id="password">
+    <div class="label">Log in password</div>
+	<input name="login_password" value="{{settings["password"]}}" />
+	</div>
+
+    <h4>FTP Server</h4>
+    <hr>
 	<div class="label">Enable FTP server</div>
-	<input type="checkbox" name="enable_ftp_server" {{'checked' if settings["enable_ftp_server"] else ''}} />
+	<input type="checkbox" name="enable_ftp_server" id="enable_ftp_server" onclick="setShowFTPSettings()" {{'checked' if settings["enable_ftp_server"] else ''}} />
 
-	<div class="label">FTP username</div>
-	<input name="ftp_username" value="{{settings["ftp_username"]}}" />
+    <div id="ftp">
+        <div class="label">FTP username</div>
+        <input name="ftp_username" value="{{settings["ftp_username"]}}" />
 
-	<div class="label">FTP password</div>
-	<input name="ftp_password" value="{{settings["ftp_password"]}}"" />
+        <div class="label">FTP password</div>
+        <input name="ftp_password" value="{{settings["ftp_password"]}}"" />
 
-    <div class="label">FTP port</div>
-	<input type="number" name="ftp_port" value="{{settings["ftp_port"]}}"" />
+        <div class="label">FTP port</div>
+        <input type="number" name="ftp_port" value="{{settings["ftp_port"]}}"" />
+    </div>
 
 	<button>Save</button>
 </form>
+<script>
+    function setShowPasswordField() {
+        let checkBox = document.getElementById('generate_password')
+        let passwordDiv = document.getElementById('password')
+        if (checkBox.checked) {
+            passwordDiv.style.visibility = 'hidden'
+            passwordDiv.style.display = 'none';
+        } else {
+            passwordDiv.style.visibility = 'visible'
+            passwordDiv.style.display = 'block';
+        }
+    }
+    function setShowFTPSettings() {
+        let checkBox = document.getElementById('enable_ftp_server')
+        let ftpDiv = document.getElementById('ftp')
+        if (checkBox.checked) {
+            ftpDiv.style.visibility = 'visible'
+            ftpDiv.style.display = 'block';
+        } else {
+            ftpDiv.style.visibility = 'hidden'
+            ftpDiv.style.display = 'none';
+        }
+    }
+    setShowPasswordField()
+    setShowFTPSettings()
+</script>

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -7,7 +7,9 @@
 
     <div id="password">
     <div class="label">Log in password</div>
-	<input name="login_password" value="{{settings["password"]}}" />
+	<input name="login_password" id="login_password" type="password" placeholder="password" pattern=".{8,}" title="8 characters or more" oninput="setConfirmPasswordRequired(this)"/>
+	<input id="confirm_login_password" type="password" placeholder="confirm password" oninput="passwordMatchCheck(this)"/>
+
 	</div>
 
     <h4>FTP Server</h4>
@@ -17,40 +19,62 @@
 
     <div id="ftp">
         <div class="label">FTP username</div>
-        <input name="ftp_username" value="{{settings["ftp_username"]}}" />
+        <input name="ftp_username" value="{{settings["ftp_username"]}}" pattern=".{5,}" title="5 characters or more"/>
 
         <div class="label">FTP password</div>
-        <input name="ftp_password" value="{{settings["ftp_password"]}}"" />
+        <input name="ftp_password" value="{{settings["ftp_password"]}}" pattern=".{8,}" title="8 characters or more"/>
 
         <div class="label">FTP port</div>
-        <input type="number" name="ftp_port" value="{{settings["ftp_port"]}}"" />
+        <input type="number" name="ftp_port" value="{{settings["ftp_port"]}}" min="1025" max="65535"/>
     </div>
 
 	<button>Save</button>
 </form>
 <script>
     function setShowPasswordField() {
-        let checkBox = document.getElementById('generate_password')
-        let passwordDiv = document.getElementById('password')
+        let checkBox = document.getElementById('generate_password');
+        let passwordDiv = document.getElementById('password');
+        let passwordField = document.getElementById('login_password');
         if (checkBox.checked) {
-            passwordDiv.style.visibility = 'hidden'
+            passwordDiv.style.visibility = 'hidden';
             passwordDiv.style.display = 'none';
+            passwordField.required = false;
         } else {
-            passwordDiv.style.visibility = 'visible'
+            passwordDiv.style.visibility = 'visible';
             passwordDiv.style.display = 'block';
+            % if not password_is_set:
+                passwordField.required = true;
+            % end
         }
     }
     function setShowFTPSettings() {
-        let checkBox = document.getElementById('enable_ftp_server')
-        let ftpDiv = document.getElementById('ftp')
+        let checkBox = document.getElementById('enable_ftp_server');
+        let ftpDiv = document.getElementById('ftp');
         if (checkBox.checked) {
-            ftpDiv.style.visibility = 'visible'
+            ftpDiv.style.visibility = 'visible';
             ftpDiv.style.display = 'block';
         } else {
-            ftpDiv.style.visibility = 'hidden'
+            ftpDiv.style.visibility = 'hidden';
             ftpDiv.style.display = 'none';
         }
     }
+    function passwordMatchCheck(input) {
+        let passwordField = document.getElementById('login_password');
+        if (input.value != passwordField.value) {
+            input.setCustomValidity('Must match password field');
+        } else {
+            input.setCustomValidity('');
+        }
+    }
+    function setConfirmPasswordRequired(input) {
+        let confirm = document.getElementById('confirm_login_password')
+        if (input.value.length > 0) {
+            confirm.required = true
+        } else {
+            confirm.required = false
+        }
+    }
+
     setShowPasswordField()
     setShowFTPSettings()
 </script>


### PR DESCRIPTION
This pull requests adds authentication throughout all of steam-buddy. If you're not logged in, you can't do anything. Logging in is done through a log in screen which only asks for a password. This password is randomly generated each time the login page is load, after which it is communicated ot the user automatically by launching a full screen application showing it.

The system also supports setting the password and keeping it the same, for which there is an option in settings. Bcrypt is used to save the password in the settings file as a salted hash.

It was tested on my machine and on GamerOS 15.

This adds the following dependencies:
- python-beaker
- python-pygame
- python-psutil
- python-bcrypt

The current implementation has the following potential security issues:
- There is no brute force protection
- Generated passwords always have the same length
- ~~Passwords are saved in plain text~~
- Only a password is asked, nothing else
- Stealing the session cookie is probably a bit easier than I would like, since it the user's IP address is not stored in the session. It does check the user agent, though
- Cookies are not exclusive to a user for afaik. This is a limitation of beaker. Multiple people using steam-buddy at the same time will result in everybody being logged out.

Edit:: Added python-bcrypt as dependecy and passwords are no longer saved in plain text
Edit 2: Updated to current state of PR