### PR TITLE
Suggest names and images from Steamgrid when adding games

### DIFF
--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -4,6 +4,7 @@ from steam_buddy.settings import Settings
 from steam_buddy.ftp.server import Server as FTPServer
 from steam_buddy.authenticator import Authenticator, generate_password
 from steam_buddy.ssh_keys import SSHKeys
+from steam_buddy.steamgrid.steamgrid import Steamgrid
 
 DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
@@ -60,3 +61,5 @@ AUTHENTICATOR = Authenticator(AUTHENTICATOR_PATH, password_length=8)
 FTP_SERVER = FTPServer(SETTINGS_HANDLER)
 
 SSH_KEY_HANDLER = SSHKeys(os.path.expanduser('~/.ssh/authorized_keys'))
+
+STEAMGRID_HANDLER = Steamgrid("f092e3045f4f041c4bf8a9db2cb8c25c")

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -183,6 +183,8 @@ def shortcut_update():
         banner_path = upsert_file(BANNER_DIR, platform, name, banner)
     elif banner_url:
         banner_path = os.path.join(BANNER_DIR, platform, "{}.png".format(name))
+        if not os.path.isdir(os.path.dirname(banner_path)):
+            os.makedirs(os.path.dirname(banner_path))
         download = requests.get(banner_url)
         with open(banner_path, "wb") as banner_file:
             banner_file.write(download.content)

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -6,7 +6,7 @@ import yaml
 import bcrypt
 from bottle import app, route, template, static_file, redirect, abort, request, response
 from beaker.middleware import SessionMiddleware
-from steam_buddy.config import PLATFORMS, FLATHUB_HANDLER, SSH_KEY_HANDLER, AUTHENTICATOR, SETTINGS_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR, SESSION_OPTIONS
+from steam_buddy.config import PLATFORMS, FLATHUB_HANDLER, SSH_KEY_HANDLER, AUTHENTICATOR, SETTINGS_HANDLER, STEAMGRID_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR, SESSION_OPTIONS
 from steam_buddy.functions import load_shortcuts, sanitize, upsert_file, delete_file
 
 server = SessionMiddleware(app(), SESSION_OPTIONS)
@@ -402,3 +402,13 @@ def authenticate():
 def forgot_password():
     SETTINGS_HANDLER.set_setting('keep_password', False)
     return redirect('/login')
+
+
+@route('/steamgrid/search/<search_string>')
+def steamgrid_search(search_string):
+    return STEAMGRID_HANDLER.search_games(search_string)
+
+
+@route('/steamgrid/images/<game_id>')
+def steamgrid_get_images(game_id):
+    return STEAMGRID_HANDLER.get_images(game_id)

--- a/steam_buddy/steamgrid/steamgrid.py
+++ b/steam_buddy/steamgrid/steamgrid.py
@@ -1,0 +1,24 @@
+import requests
+import html
+
+
+class Steamgrid:
+
+    def __init__(self, api_key):
+        self.__api_key = api_key
+
+    def search_games(self, search_string):
+        url = "https://www.steamgriddb.com/api/v2/search/autocomplete/{}".format(html.escape(search_string))
+        response = self.__request(url)
+        return response.text
+
+    def get_images(self, game_id):
+        url = "https://www.steamgriddb.com/api/v2/grids/game/{}".format(game_id)
+        response = self.__request(url)
+        return response.text
+
+    def __request(self, url):
+        headers = {
+            'Authorization': "Bearer {}".format(self.__api_key)
+        }
+        return requests.get(url, headers=headers)

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -192,6 +192,30 @@
 		    top : 5px;
 		    font-size: 40px;
 		}
+		.game-name-suggestion {
+          position: relative;
+          display: inline-block:
+          width: 100%;
+          background: #3268a8;
+		  color: white;
+          border: none;
+          z-index: 99;
+          /*position the autocomplete items to be the same width as the container:*/
+          top: 100%;
+          left: 0;
+          right: 0;
+          cursor: pointer;
+        }
+        .game-image-suggestion {
+          cursor: pointer;
+        }
+        .game-name-suggestion:hover {
+            background: #10131c;
+        }
+        .steamgridapi {
+           position: relative;
+            display: inline-block;
+        }
 	</style>
 </head>
 <body>

--- a/views/new.tpl
+++ b/views/new.tpl
@@ -40,6 +40,8 @@
     function setImage(url) {
         let field = document.getElementById("banner-url")
         field.value = url
+        let gameImages = document.getElementById("game-images");
+        gameImages.innerHTML = '';
     }
     async function setGameName(gameName, gameId) {
         let field = await document.getElementById("gamename");

--- a/views/new.tpl
+++ b/views/new.tpl
@@ -5,17 +5,20 @@
 
 	<div class="label">Name</div>
 	<div class="steamgridapi">
-	    <input id="gamename" type="text" name="name" oninput="completeGameName(this)" value="{{name}}" {{ 'disabled' if isEditing else '' }}/>
+	    <input id="gamename" type="text" name="name" oninput="completeGameName(this)" value="{{name}}" required {{ 'disabled' if isEditing else '' }}/>
 	    <div id="game-options"></div>
 	</div>
 
 	<div class="label">Hidden</div>
 	<input type="checkbox" name="hidden" {{'checked' if hidden else ''}} />
 
-	<div class="label">Banner</div>
-	<input type="file" name="banner" />
+	<div class="label">Banner URL</div>
 	<input id="banner-url" name="banner-url" />
 	<div id="game-images"></div>
+
+
+	<div class="label">Banner upload</div>
+	<input type="file" name="banner" />
 
 	<div class="label">Content</div>
 	<input type="file" name="content" />

--- a/views/new.tpl
+++ b/views/new.tpl
@@ -1,16 +1,21 @@
 % rebase('base.tpl')
-<form action="/shortcuts/{{ 'edit' if isEditing else 'new' }}" method="post" enctype="multipart/form-data">
+<form autocomplete="off" action="/shortcuts/{{ 'edit' if isEditing else 'new' }}" method="post" enctype="multipart/form-data">
 	<input type="hidden" value="{{name}}" name="original_name">
 	<input type="hidden" value="{{platform}}" name="platform">
 
 	<div class="label">Name</div>
-	<input type="text" name="name" value="{{name}}" {{ 'disabled' if isEditing else '' }}/>
+	<div class="steamgridapi">
+	    <input id="gamename" type="text" name="name" oninput="completeGameName(this)" value="{{name}}" {{ 'disabled' if isEditing else '' }}/>
+	    <div id="game-options"></div>
+	</div>
 
 	<div class="label">Hidden</div>
 	<input type="checkbox" name="hidden" {{'checked' if hidden else ''}} />
 
 	<div class="label">Banner</div>
 	<input type="file" name="banner" />
+	<input id="banner-url" name="banner-url" />
+	<div id="game-images"></div>
 
 	<div class="label">Content</div>
 	<input type="file" name="content" />
@@ -29,3 +34,49 @@
 	<button class="delete">Delete</button>
 </form>
 % end
+
+<script>
+    let games = ["Super Mario 64", "Super Mario Bros", "Super Mario World", "Super Gradius"];
+    function setImage(url) {
+        let field = document.getElementById("banner-url")
+        field.value = url
+    }
+    async function setGameName(gameName, gameId) {
+        let field = await document.getElementById("gamename");
+        let gameOptions = await document.getElementById("game-options");
+        let gameImages = await document.getElementById("game-images");
+        field.value = gameName;
+        gameOptions.innerHTML = '';
+        gameImages.innerHTML = '';
+
+        url = "/steamgrid/images/" + gameId;
+        response = await fetch(url);
+        images = await response.json();
+        imagesElement = await document.getElementById("game-images");
+        images.data.forEach(function (image) {
+            entry = document.createElement("IMG");
+            entry.setAttribute("class", "game-image-suggestion");
+            entry.setAttribute("src", image.thumb);
+            entry.setAttribute("onclick", "setImage(\"" + image.url + "\")");
+            imagesElement.appendChild(entry);
+        });
+    }
+    async function completeGameName(input) {
+        url = "/steamgrid/search/" + input.value;
+        response = await fetch(url);
+        games = await response.json();
+        console.log(games);
+        if (!games.success) {
+            return;
+        }
+        gameOptions = await document.getElementById("game-options");
+        gameOptions.innerHTML = '';
+        games.data.forEach(function (game) {
+            entry = document.createElement("DIV");
+            entry.setAttribute("class", "game-name-suggestion");
+            entry.setAttribute("onclick", "setGameName(\"" + game.name + "\", " + game.id +")");
+            entry.innerHTML = game.name;
+            gameOptions.appendChild(entry);
+        });
+    }
+</script>

--- a/views/new.tpl
+++ b/views/new.tpl
@@ -95,4 +95,28 @@
             gameOptions.appendChild(entry);
         });
     }
+
+    async function suggestImagesOnEdit() {
+        let field = document.getElementById("gamename")
+        if (field.value) {
+            url = "/steamgrid/search/" + field.value;
+            response = await fetch(url);
+            games = await response.json();
+
+            if (!games.success) {
+            return;
+            }
+
+            games.data.forEach(function (game) {
+                if (game.name == field.value) {
+                    setGameName(game.name, game.id);
+                }
+            });
+        }
+    }
+    // When clicking somewhere, close the suggestions
+    document.addEventListener("click", function (e) {
+        document.getElementById("game-options").innerHTML = '';
+    });
+    suggestImagesOnEdit();
 </script>

--- a/views/new.tpl
+++ b/views/new.tpl
@@ -82,7 +82,6 @@
         url = "/steamgrid/search/" + input.value;
         response = await fetch(url);
         games = await response.json();
-        console.log(games);
         if (!games.success) {
             return;
         }

--- a/views/new.tpl
+++ b/views/new.tpl
@@ -67,6 +67,18 @@
         });
     }
     async function completeGameName(input) {
+        if (input.value.length < 3) {
+            return;
+        }
+        let value = input.value
+        let promise = new Promise((res, rej) => {
+            setTimeout(() => res("Now it's done!"), 250)
+        });
+        await promise;
+        if (value != input.value) {
+            return;
+        }
+
         url = "/steamgrid/search/" + input.value;
         response = await fetch(url);
         games = await response.json();


### PR DESCRIPTION
This also allows you to add your own URL to an image, but it heavily incentivizes using Steamgrid. I also made the name field required in the front end, since it already was in the back end.