### PR TITLE
Fixed setup.py adding tests to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from glob import glob
 setup(
     name="Steam-Buddy",
     version="0.4.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     scripts=['steam-buddy'],
 
     data_files=[


### PR DESCRIPTION
I just found this was an issue with Minigalaxy, because I had a conflict with the tests package from the steam-buddy package