### PR TITLE
Fix steam-buddy-authenticator not being found

### DIFF
--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -12,7 +12,7 @@ RESOURCE_DIR = os.getcwd()
 if not os.path.isfile(os.path.join(RESOURCE_DIR, 'views/base.tpl')):
 	RESOURCE_DIR = "/usr/share/steam-buddy"
 
-AUTHENTICATOR_PATH = os.path.abspath('steam-buddy-authenticator')
+AUTHENTICATOR_PATH = os.path.abspath('bin/steam-buddy-authenticator')
 if not os.path.isfile(AUTHENTICATOR_PATH):
 	AUTHENTICATOR_PATH = "/usr/share/steam-buddy/bin/steam-buddy-authenticator"
 


### PR DESCRIPTION
Because steam-buddy-authenticator was moved, config.py could not longer
find it on systems which didn't have steam-buddy installed yet.