### PR TITLE
Add initial virtual keyboard support

### DIFF
--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -444,6 +444,20 @@ def mangohud():
 	finally:
 		redirect('/')
 
+@route('/virtual_keyboard')
+@authenticate
+def type():
+    return template('virtual_keyboard.tpl')
+
+@route('/virtual_keyboard/string', method='POST')
+@authenticate
+def type_string():
+    str = sanitize(request.forms.get('str'))
+    try:
+        subprocess.call(["xdotool", "type", "--", str])
+    finally:
+        redirect('/virtual_keyboard')
+
 
 @route('/exit_game')
 @authenticate

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -344,6 +344,7 @@
                 <a href="/steam/restart">Restart Steam</a>
                 <a href="/steam/compositor">Toggle Compositor</a>
                 <a href="/mangohud">Toggle MangoHud</a>
+                <a href="/virtual_keyboard">Virtual Keyboard</a>
                 <a href="/logout">Log Out</a>
             </div>
             <a href="javascript:void(0);" id="mainmenuicon" onclick="toggleMenu('mainmenu')">&#9881;</a>

--- a/views/virtual_keyboard.tpl
+++ b/views/virtual_keyboard.tpl
@@ -1,0 +1,9 @@
+% rebase('base.tpl')
+<form action="/virtual_keyboard/string" method="post" enctype="multipart/form-data">
+    <h4>Type something (like passwords or usernames)</h4>
+    <div id="str">
+    <div class="label">Enter the thing to type</div>
+	<input name="str" id="str"/>
+	</div>
+	<button>Submit</button>
+</script>


### PR DESCRIPTION
I was a bit annoyed at typing my 20+ character passwords manually (for MC or uplay, for example), so I've hacked this together to eliminate it. May also be useful for other things.

Untested, since I wasn't sure how to add it on gamer-os and it seems simple enough that it may even work like this. Hopefully someone else can test this