### PR TITLE
Add a "Toggle Steam Overlay" button

### DIFF
--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -435,6 +435,13 @@ def steam_compositor():
     finally:
         redirect('/')
 
+@route('/steam/overlay')
+@authenticate
+def steam_overlay():
+	try:
+		subprocess.call(["xdotool", "key", "shift+Tab"])
+	finally:
+		redirect('/')
 
 @route('/mangohud')
 @authenticate

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -343,6 +343,7 @@
                 <a href="/exit_game">Exit Game</a>
                 <a href="/steam/restart">Restart Steam</a>
                 <a href="/steam/compositor">Toggle Compositor</a>
+                <a href="/steam/overlay">Toggle Steam Overlay</a>
                 <a href="/mangohud">Toggle MangoHud</a>
                 <a href="/virtual_keyboard">Virtual Keyboard</a>
                 <a href="/logout">Log Out</a>


### PR DESCRIPTION
For people like me that use a gamepad without a "Home" button (I use a Playstation 2 controller), there's currently no convenient way to bring up the Steam overlay. This pull requests adds a button for that in Steam Buddy.

Tested & working on my setup.