### PR TITLE
Generate banners for new shortcuts if none is set

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,5 +8,6 @@ psutil
 flake8
 WebTest
 bcrypt
+Pillow
 pytest
 pytidylib

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ beaker
 pygame
 psutil
 bcrypt
+Pillow

--- a/steam_buddy/functions.py
+++ b/steam_buddy/functions.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import yaml
 from steam_buddy.config import SHORTCUT_DIR
+from PIL import Image, ImageFont, ImageDraw
 
 
 def sanitize(string):
@@ -99,3 +100,27 @@ def delete_file(base_dir, platform, name):
             shutil.rmtree(file_dir)
 
     delete_file_link(base_dir, platform, name)
+
+
+def generate_banner(text, path):
+    # The thumbnail size used by Steam is set
+    banner_width = 460
+    banner_height = 215
+    banner = Image.new('RGB', (banner_width, banner_height), color=(0, 0, 0))
+
+    font = ImageFont.truetype("/usr/share/fonts/TTF/DejaVuSansMono-Bold.ttf", 24)
+
+    text_width, text_height = font.getsize(text)
+
+    # Shorten the text if it doesn't fit on the image
+    while text_width > banner_width:
+        text = text[:-4] + "..."
+        text_width, text_height = font.getsize(text)
+
+    text_x = int(banner_width / 2 - text_width / 2)
+    text_y = int(banner_height / 2 - text_height / 2)
+
+    title = ImageDraw.Draw(banner)
+    title.text((text_x, text_y), text, font=font, fill=(255, 255, 255))
+
+    banner.save(path)


### PR DESCRIPTION
This uses the Pillow library to generate a simple banner with the title
of the game on it.
It currently uses a black background with a white font. It will
shorten titles if they don't fit on the banner.

This requires 2 dependencies:
- ttf-dejavu
- python-pillow

The package ttf-dejavu should already be a dependency for steam-buddy
(not sure if it is, though), since the authenticator uses it too.