### PR TITLE
Tweak Retroarch config for audio latency

### DIFF
--- a/config/retroarch-common.cfg
+++ b/config/retroarch-common.cfg
@@ -7,6 +7,7 @@ video_fullscreen = "true"
 video_smooth = "false"
 video_scale_integer = "false"
 video_sync = "false"
+audio_latency = "90"
 
 input_player1_analog_dpad_mode = "1"
 input_player2_analog_dpad_mode = "1"


### PR DESCRIPTION
I experienced some pops and clicks in Super Mario 64 game that went away with this setting (previously set at 64ms). This shouldn't create any side effects at all.