### PR TITLE
Mangohud handle configuration file

### DIFF
--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -53,6 +53,7 @@ PLATFORMS = {
 }
 
 SETTINGS_DEFAULT = {
+    "enable_mangohud": True,
     "enable_ftp_server": False,
     "ftp_username": "gamer",
     "ftp_password": generate_password(12),

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -4,6 +4,7 @@ from steam_buddy.ftp.server import Server as FTPServer
 from steam_buddy.authenticator import Authenticator, generate_password
 from steam_buddy.ssh_keys import SSHKeys
 from steam_buddy.steamgrid.steamgrid import Steamgrid
+from steam_buddy.mangohud_config import MangoHudConfig
 
 DATA_DIR = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 CONFIG_DIR = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
@@ -22,6 +23,8 @@ BANNER_DIR = DATA_DIR + '/steam-buddy/banners'
 CONTENT_DIR = DATA_DIR + '/steam-buddy/content'
 SETTINGS_DIR = DATA_DIR + '/steam-buddy/settings'
 UPLOADS_DIR = os.path.join(CACHE_DIR, 'steam-buddy', 'uploads')
+ENVIRONMENT_DIR = CONFIG_DIR + "/environment.d"
+MANGOHUD_DIR = CONFIG_DIR + "/MangoHud"
 
 PLATFORMS = {
     "32x":         "32X",
@@ -78,3 +81,5 @@ FTP_SERVER = FTPServer(SETTINGS_HANDLER)
 SSH_KEY_HANDLER = SSHKeys(os.path.expanduser('~/.ssh/authorized_keys'))
 
 STEAMGRID_HANDLER = Steamgrid("f092e3045f4f041c4bf8a9db2cb8c25c")
+
+MANGOHUD_HANDLER = MangoHudConfig(SETTINGS_HANDLER, ENVIRONMENT_DIR, MANGOHUD_DIR)

--- a/steam_buddy/config.py
+++ b/steam_buddy/config.py
@@ -23,7 +23,6 @@ BANNER_DIR = DATA_DIR + '/steam-buddy/banners'
 CONTENT_DIR = DATA_DIR + '/steam-buddy/content'
 SETTINGS_DIR = DATA_DIR + '/steam-buddy/settings'
 UPLOADS_DIR = os.path.join(CACHE_DIR, 'steam-buddy', 'uploads')
-ENVIRONMENT_DIR = CONFIG_DIR + "/environment.d"
 MANGOHUD_DIR = CONFIG_DIR + "/MangoHud"
 
 PLATFORMS = {
@@ -56,7 +55,6 @@ PLATFORMS = {
 }
 
 SETTINGS_DEFAULT = {
-    "enable_mangohud": True,
     "enable_ftp_server": False,
     "ftp_username": "gamer",
     "ftp_password": generate_password(12),
@@ -82,4 +80,4 @@ SSH_KEY_HANDLER = SSHKeys(os.path.expanduser('~/.ssh/authorized_keys'))
 
 STEAMGRID_HANDLER = Steamgrid("f092e3045f4f041c4bf8a9db2cb8c25c")
 
-MANGOHUD_HANDLER = MangoHudConfig(SETTINGS_HANDLER, ENVIRONMENT_DIR, MANGOHUD_DIR)
+MANGOHUD_HANDLER = MangoHudConfig(MANGOHUD_DIR)

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -13,9 +13,7 @@ class MangoHudConfig:
 
     def __setup_environment(self):
         if self.enabled:
-            env_dir = os.path.dirname(self.enable_file)
-            if not os.path.exists(env_dir):
-                os.mkdir(env_dir, mode=0o755)
+            self.__ensure_dir_existence(self.enable_file)
             if not os.path.exists(self.enable_file):
                 f = open(self.enable_file, "w+")
                 f.write("MANGOHUD=1")
@@ -47,13 +45,27 @@ class MangoHudConfig:
         self.__read_toggle_key()
 
     def reset_config(self) -> None:
-        config_dir = os.path.dirname(self.config_file)
-        if not os.path.exists(config_dir):
-            os.mkdir(config_dir, mode=0o755)
+        self.save_config("no_display")
+
+    def get_current_config(self):
+        if os.path.exists(self.config_file):
+            f = open(self.config_file, "r")
+            current_config = f.read()
+            f.close()
+            return current_config
+
+    def save_config(self, new_content):
+        self.__ensure_dir_existence(self.config_file)
         f = open(self.config_file, "w+")
-        f.write("no_display")
+        f.write(new_content)
         f.close()
         self.__read_toggle_key()
 
     def get_togle_hud_key(self):
         return self.toggle_key
+
+    @staticmethod
+    def __ensure_dir_existence(file):
+        d = os.path.dirname(file)
+        if not os.path.exists(d):
+            os.mkdir(d, mode=0o755)

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -22,12 +22,16 @@ class MangoHudConfig:
             if 'toggle_hud' in parser['Mangohud']:
                 self.toggle_key = parser['Mangohud']['toggle_hud']
             else:
-                self.toggle_key = "Shift_R+F12"
+                self.toggle_key = "F3"
         else:
             self.toggle_key = "Shift_R+F12"
 
     def reset_config(self) -> None:
-        self.save_config("no_display")
+        defaultt_config = [
+            "no_display",
+            'toggle_hud = F3"'
+        ]
+        self.save_config("\n".join(defaultt_config))
 
     def get_current_config(self):
         if os.path.exists(self.config_file):

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -33,6 +33,7 @@ class MangoHudConfig:
             f = open(self.config_file, "r")
             parser = ConfigParser(allow_no_value=True)
             parser.read_string("[Mangohud]\n" + f.read())
+            f.close()
             if 'toggle_hud' in parser['Mangohud']:
                 self.toggle_key = parser['Mangohud']['toggle_hud']
             else:
@@ -51,6 +52,7 @@ class MangoHudConfig:
             os.mkdir(config_dir, mode=0o755)
         f = open(self.config_file, "w+")
         f.write("no_display")
+        f.close()
         self.__read_toggle_key()
 
     def get_togle_hud_key(self):

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -29,7 +29,7 @@ class MangoHudConfig:
     def reset_config(self) -> None:
         defaultt_config = [
             "no_display",
-            'toggle_hud = F3"'
+            'toggle_hud = "F3"'
         ]
         self.save_config("\n".join(defaultt_config))
 

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -43,7 +43,7 @@ class MangoHudConfig:
         f.close()
         self.__read_toggle_key()
 
-    def get_togle_hud_key(self):
+    def get_toggle_hud_key(self):
         return self.toggle_key
 
     @staticmethod

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -1,4 +1,5 @@
 import os
+from configparser import ConfigParser
 
 
 class MangoHudConfig:
@@ -7,8 +8,8 @@ class MangoHudConfig:
         self.enable_file = env_dir + "/10-mangohud.conf"
         self.config_file = mango_dir + "/MangoHud.conf"
         self.enabled = settings_handler.get_setting("enable_mangohud")
-        self.toggle_key = "Shift_R+F12"
         self.__setup_environment()
+        self.__read_toggle_key()
 
     def __setup_environment(self):
         if self.enabled:
@@ -27,9 +28,22 @@ class MangoHudConfig:
             if os.path.exists(self.enable_file):
                 os.remove(self.enable_file)
 
+    def __read_toggle_key(self):
+        if os.path.exists(self.config_file):
+            f = open(self.config_file, "r")
+            parser = ConfigParser(allow_no_value=True)
+            parser.read_string("[Mangohud]\n" + f.read())
+            if 'toggle_hud' in parser['Mangohud']:
+                self.toggle_key = parser['Mangohud']['toggle_hud']
+            else:
+                self.toggle_key = "Shift_R+F12"
+        else:
+            self.toggle_key = "Shift_R+F12"
+
     def set_enabled(self, enabled) -> None:
         self.enabled = enabled
         self.__setup_environment()
+        self.__read_toggle_key()
 
     def reset_config(self) -> None:
         config_dir = os.path.dirname(self.config_file)
@@ -37,6 +51,7 @@ class MangoHudConfig:
             os.mkdir(config_dir, mode=0o755)
         f = open(self.config_file, "w+")
         f.write("no_display")
+        self.__read_toggle_key()
 
     def get_togle_hud_key(self):
         return self.toggle_key

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -24,7 +24,7 @@ class MangoHudConfig:
             else:
                 self.toggle_key = "Shift_R+F12"
         else:
-            self.toggle_key = "Sh ift_R+F12"
+            self.toggle_key = "Shift_R+F12"
 
     def reset_config(self) -> None:
         self.save_config("no_display")

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -1,0 +1,42 @@
+import os
+
+
+class MangoHudConfig:
+
+    def __init__(self, settings_handler, env_dir, mango_dir):
+        self.enable_file = env_dir + "/10-mangohud.conf"
+        self.config_file = mango_dir + "/MangoHud.conf"
+        self.enabled = settings_handler.get_setting("enable_mangohud")
+        self.toggle_key = "Shift_R+F12"
+        self.__setup_environment()
+
+    def __setup_environment(self):
+        if self.enabled:
+            env_dir = os.path.dirname(self.enable_file)
+            if not os.path.exists(env_dir):
+                os.mkdir(env_dir, mode=0o755)
+            if not os.path.exists(self.enable_file):
+                f = open(self.enable_file, "w+")
+                f.write("MANGOHUD=1")
+                f.close()
+            if not os.path.exists(self.config_file):
+                self.reset_config()
+            else:
+                pass
+        else:
+            if os.path.exists(self.enable_file):
+                os.remove(self.enable_file)
+
+    def set_enabled(self, enabled) -> None:
+        self.enabled = enabled
+        self.__setup_environment()
+
+    def reset_config(self) -> None:
+        config_dir = os.path.dirname(self.config_file)
+        if not os.path.exists(config_dir):
+            os.mkdir(config_dir, mode=0o755)
+        f = open(self.config_file, "w+")
+        f.write("no_display")
+
+    def get_togle_hud_key(self):
+        return self.toggle_key

--- a/steam_buddy/mangohud_config.py
+++ b/steam_buddy/mangohud_config.py
@@ -4,27 +4,14 @@ from configparser import ConfigParser
 
 class MangoHudConfig:
 
-    def __init__(self, settings_handler, env_dir, mango_dir):
-        self.enable_file = env_dir + "/10-mangohud.conf"
+    def __init__(self, mango_dir):
         self.config_file = mango_dir + "/MangoHud.conf"
-        self.enabled = settings_handler.get_setting("enable_mangohud")
         self.__setup_environment()
         self.__read_toggle_key()
 
     def __setup_environment(self):
-        if self.enabled:
-            self.__ensure_dir_existence(self.enable_file)
-            if not os.path.exists(self.enable_file):
-                f = open(self.enable_file, "w+")
-                f.write("MANGOHUD=1")
-                f.close()
-            if not os.path.exists(self.config_file):
-                self.reset_config()
-            else:
-                pass
-        else:
-            if os.path.exists(self.enable_file):
-                os.remove(self.enable_file)
+        if not os.path.exists(self.config_file):
+            self.reset_config()
 
     def __read_toggle_key(self):
         if os.path.exists(self.config_file):
@@ -37,12 +24,7 @@ class MangoHudConfig:
             else:
                 self.toggle_key = "Shift_R+F12"
         else:
-            self.toggle_key = "Shift_R+F12"
-
-    def set_enabled(self, enabled) -> None:
-        self.enabled = enabled
-        self.__setup_environment()
-        self.__read_toggle_key()
+            self.toggle_key = "Sh ift_R+F12"
 
     def reset_config(self) -> None:
         self.save_config("no_display")
@@ -55,7 +37,7 @@ class MangoHudConfig:
             return current_config
 
     def save_config(self, new_content):
-        self.__ensure_dir_existence(self.config_file)
+        self.ensure_dir_for_file(self.config_file)
         f = open(self.config_file, "w+")
         f.write(new_content)
         f.close()
@@ -65,7 +47,7 @@ class MangoHudConfig:
         return self.toggle_key
 
     @staticmethod
-    def __ensure_dir_existence(file):
+    def ensure_dir_for_file(file):
         d = os.path.dirname(file)
         if not os.path.exists(d):
             os.mkdir(d, mode=0o755)

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -493,7 +493,7 @@ def steam_overlay():
 @route('/mangohud')
 @authenticate
 def mangohud():
-    key = MANGOHUD_HANDLER.get_togle_hud_key()
+    key = MANGOHUD_HANDLER.get_toggle_hud_key()
     try:
         subprocess.call(["xdotool", "key", key])
     finally:

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -499,9 +499,26 @@ def mangohud():
     finally:
         redirect('/')
 
+
+@route('/mangohud/save_config', method='POST')
+@authenticate
+def mangohud_save_config():
+    new_content = request.forms.get('new_content')
+    MANGOHUD_HANDLER.save_config(new_content)
+    redirect('/mangohud/edit_config')
+
+
+@route('/mangohud/edit_config')
+@authenticate
+def mangohud_edit():
+    current_content = MANGOHUD_HANDLER.get_current_config()
+    return template('mangohud_edit.tpl', file_content=current_content)
+
+
 def retroarch_cmd(msg):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.sendto(bytes(msg, "utf-8"), ('127.0.0.1', 55355))
+
 
 @route('/retroarch/load_state')
 @authenticate
@@ -511,6 +528,7 @@ def retro_load_state():
     finally:
         redirect('/')
 
+
 @route('/retroarch/save_state')
 @authenticate
 def retro_save_state():
@@ -518,6 +536,7 @@ def retro_save_state():
         retroarch_cmd('SAVE_STATE')
     finally:
         redirect('/')
+
 
 @route('/virtual_keyboard')
 @authenticate

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -460,7 +460,7 @@ def settings_update():
 @authenticate
 def mangohud_reset():
     MANGOHUD_HANDLER.reset_config()
-    redirect('/settings')
+    redirect('/')
 
 
 @route('/steam/restart')
@@ -505,7 +505,7 @@ def mangohud():
 def mangohud_save_config():
     new_content = request.forms.get('new_content')
     MANGOHUD_HANDLER.save_config(new_content)
-    redirect('/mangohud/edit_config')
+    redirect('/')
 
 
 @route('/mangohud/edit_config')

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -456,6 +456,13 @@ def settings_update():
     redirect('/settings')
 
 
+@route('/settings/reset_mangohud', method='POST')
+@authenticate
+def mangohud_reset():
+    MANGOHUD_HANDLER.reset_config()
+    redirect('/settings')
+
+
 @route('/steam/restart')
 @authenticate
 def steam_restart():

--- a/steam_buddy/server.py
+++ b/steam_buddy/server.py
@@ -12,7 +12,7 @@ import shutil
 import unicodedata
 from bottle import app, route, template, static_file, redirect, abort, request, response
 from beaker.middleware import SessionMiddleware
-from steam_buddy.config import PLATFORMS, SSH_KEY_HANDLER, AUTHENTICATOR, SETTINGS_HANDLER, STEAMGRID_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR, UPLOADS_DIR, SESSION_OPTIONS
+from steam_buddy.config import PLATFORMS, SSH_KEY_HANDLER, AUTHENTICATOR, SETTINGS_HANDLER, STEAMGRID_HANDLER, FTP_SERVER, RESOURCE_DIR, BANNER_DIR, CONTENT_DIR, SHORTCUT_DIR, UPLOADS_DIR, SESSION_OPTIONS, MANGOHUD_HANDLER
 from steam_buddy.functions import load_shortcuts, sanitize, upsert_file, delete_file, generate_banner
 from steam_buddy.auth_decorator import authenticate
 from steam_buddy.platforms.epic_store import EpicStore
@@ -486,8 +486,9 @@ def steam_overlay():
 @route('/mangohud')
 @authenticate
 def mangohud():
+    key = MANGOHUD_HANDLER.get_togle_hud_key()
     try:
-        subprocess.call(["xdotool", "key", "F3"])
+        subprocess.call(["xdotool", "key", key])
     finally:
         redirect('/')
 

--- a/views/base.tpl
+++ b/views/base.tpl
@@ -66,6 +66,7 @@
                 <a href="/steam/compositor">Toggle Compositor</a>
                 <a href="/steam/overlay">Toggle Steam Overlay</a>
                 <a href="/mangohud">Toggle MangoHud</a>
+                <a href="/mangohud/edit_config">MangoHud Configuration</a>
                 <a href="/virtual_keyboard">Virtual Keyboard</a>
                 <a href="/logout">Log Out</a>
             </div>

--- a/views/mangohud_edit.tpl
+++ b/views/mangohud_edit.tpl
@@ -1,0 +1,11 @@
+% rebase('base.tpl')
+<form action="/mangohud/save_config" method="post" enctype="multipart/form-data">
+    <h4>MangoHud configuration file</h4>
+    <hr>
+    You'll be able to edit MangoHud configuration here by setting it's content.
+    <div>
+        <textarea name="new_content" id="new_content">{{file_content}}</textarea>
+    </div>
+
+	<button>Save</button>
+</form>

--- a/views/mangohud_edit.tpl
+++ b/views/mangohud_edit.tpl
@@ -2,7 +2,7 @@
 <form action="/mangohud/save_config" method="post" enctype="multipart/form-data">
     <h4>MangoHud configuration file</h4>
     <hr>
-    You'll be able to edit MangoHud.conf here by setting it's content.
+    You'll be able to edit MangoHud.conf here by setting its content.
     <div>
         <textarea name="new_content" id="new_content" cols=40 rows=10>{{file_content}}</textarea>
     </div>

--- a/views/mangohud_edit.tpl
+++ b/views/mangohud_edit.tpl
@@ -2,9 +2,9 @@
 <form action="/mangohud/save_config" method="post" enctype="multipart/form-data">
     <h4>MangoHud configuration file</h4>
     <hr>
-    You'll be able to edit MangoHud configuration here by setting it's content.
+    You'll be able to edit MangoHud.conf here by setting it's content.
     <div>
-        <textarea name="new_content" id="new_content">{{file_content}}</textarea>
+        <textarea name="new_content" id="new_content" cols=40 rows=10>{{file_content}}</textarea>
     </div>
 
 	<button>Save</button>

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -1,5 +1,12 @@
 % rebase('base.tpl')
 <form action="/settings/update" method="post" enctype="multipart/form-data">
+    <h4>MangoHud</h4>
+    <hr>
+    MangoHud confguration. You'll be able to reset the default configuration and set it onhere.
+    <div class="label">Enable MangoHud</div>
+	<input type="checkbox" name="enable_mangohud" id="enable_mangohud"  {{'checked' if settings["enable_mangohud"] else ''}} />
+	<button>Reset configuration</button>
+
     <h4>Logging in</h4>
     <hr>
     By default a random password is shown on your TV every time you try to log in here. This can be disabled by configuring a set password.

--- a/views/settings.tpl
+++ b/views/settings.tpl
@@ -2,10 +2,8 @@
 <form action="/settings/update" method="post" enctype="multipart/form-data">
     <h4>MangoHud</h4>
     <hr>
-    MangoHud confguration. You'll be able to reset the default configuration and set it onhere.
-    <div class="label">Enable MangoHud</div>
-	<input type="checkbox" name="enable_mangohud" id="enable_mangohud"  {{'checked' if settings["enable_mangohud"] else ''}} />
-	<button>Reset configuration</button>
+    You'll be able to reset the default MangoHud configuration here.
+	<button formaction="/settings/reset_mangohud">Reset configuration</button>
 
     <h4>Logging in</h4>
     <hr>


### PR DESCRIPTION
This is the initial setup to handle MangoHud configuration via `~/.config/MangoHud/MangoHud.conf` file;

In this initial state it will:
- Check if a `ManagoHud.conf` file exists and if not, create it with minimal configuration (currently only sets the `no_display` option)
- If `MangoHud.conf` file exists it will try to read `toggle_hud` keycode, if not, will be set to the ManguHud default `Shift_R+F12`.

For this to work [this line should be removed in steamos-compositor-plus](https://github.com/gamer-os/steamos-compositor-plus/blob/4adcdb70fd9a1ca59ecc434e58094937862836a2/usr/bin/steamos-session#L10)

This fixes https://github.com/gamer-os/gamer-os/issues/206

Edit:
Added a few commits to enable the configuration to be edited by the user. Currently it does not validate the content but it's intelligent enough to catch the new toggle key if set.