### PR TITLE
Make flatpak games start reliably.

### DIFF
--- a/steam_buddy/platforms/flathub.py
+++ b/steam_buddy/platforms/flathub.py
@@ -108,7 +108,8 @@ class Flathub(StorePlatform):
             'name': content.name,
             'hidden': False,
             'banner': self.get_image_file_path(content.content_id),
-            'cmd': "flatpak run " + content.content_id,
+            'params': content.content_id,
+            'cmd': "flatpak run",
             'dir': "~",
             'tags': ["Flathub"]
         }

--- a/steam_buddy/platforms/flathub.py
+++ b/steam_buddy/platforms/flathub.py
@@ -109,8 +109,8 @@ class Flathub(StorePlatform):
             'hidden': False,
             'banner': self.get_image_file_path(content.content_id),
             'cmd': "flatpak run " + content.content_id,
-            'dir': "~"
-            'tags': ["Flathub"],
+            'dir': "~",
+            'tags': ["Flathub"]
         }
 
     def get_installed_content(self) -> list:

--- a/steam_buddy/platforms/flathub.py
+++ b/steam_buddy/platforms/flathub.py
@@ -108,8 +108,8 @@ class Flathub(StorePlatform):
             'name': content.name,
             'hidden': False,
             'banner': self.get_image_file_path(content.content_id),
-            'params': content.content_id,
-            'cmd': "flatpak run",
+            'cmd': "flatpak run " + content.content_id,
+            'dir': "~"
             'tags': ["Flathub"],
         }
 


### PR DESCRIPTION
Some flatpaks need a StartDir set to start reliably. Currently if `dir` is not set, it's set to empty string. For example SuperTux fails to start until "StartDir" is set (didn't test any other) on a desktop Steam installation.

~~Also set the command `cmd` to the full command to run the program. That way the `params` member can be used to set runtime parameters by the user if so desires as setting variables.~~